### PR TITLE
feat(back): add attic cache support

### DIFF
--- a/src/args/make-script/default.nix
+++ b/src/args/make-script/default.nix
@@ -47,7 +47,6 @@ in makeDerivation {
       replace = {
         __argShellCommands__ = __shellCommands__;
         __argShellOptions__ = __shellOptions__;
-        __argCaCert__ = __nixpkgs__.cacert;
         __argName__ = name';
         __argProjectStateDir__ = __stateDirs__.project;
         __argGlobalStateDir__ = __stateDirs__.global;

--- a/src/args/make-script/template.sh
+++ b/src/args/make-script/template.sh
@@ -46,7 +46,7 @@ function prompt_user_for_input {
 function setup {
   export HOME
   export HOME_IMPURE
-  export SSL_CERT_FILE='__argCaCert__/etc/ssl/certs/ca-bundle.crt'
+  export SSL_CERT_FILE='/etc/ssl/certs/ca-bundle.crt'
   export STATE
 
   source __argSearchPathsEmpty__/template \

--- a/src/cli/makes.nix
+++ b/src/cli/makes.nix
@@ -3,6 +3,7 @@
     "/src/cli/runtime" = makeSearchPaths {
       bin = [
         __nixpkgs__.cachix
+        __nixpkgs__.attic-client # not present in old nixpkgs
         __nixpkgs__.findutils
         __nixpkgs__.git
         __nixpkgs__.git-lfs

--- a/src/evaluator/modules/cache/default.nix
+++ b/src/evaluator/modules/cache/default.nix
@@ -18,7 +18,7 @@
               type = lib.types.str;
               default = "";
             };
-            type = lib.mkOption { type = lib.types.enum [ "cachix" ]; };
+            type = lib.mkOption { type = lib.types.enum [ "cachix" "attic" ]; };
             url = lib.mkOption { type = lib.types.str; };
             write = lib.mkOption {
               default = false;


### PR DESCRIPTION
- `cli.py` is now able to use the attic cli client
- made cache functions in `cli.py` more modular
- adjust nix type definitions